### PR TITLE
Update to modern kit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Luca Deri <deri@ntop.org>
 
 RUN apt-get update
-RUN apt-get -y -q install curl
+RUN apt-get -y -q install curl lsb-release
 RUN curl -s --remote-name http://packages.ntop.org/apt/16.04/all/apt-ntop-stable.deb
 RUN dpkg -i apt-ntop-stable.deb
 RUN rm -rf apt-ntop-stable.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Luca Deri <deri@ntop.org>
 
 RUN apt-get update
 RUN apt-get -y -q install curl
-RUN curl -s --remote-name http://packages.ntop.org/apt/14.04/all/apt-ntop.deb
-RUN sudo dpkg -i apt-ntop.deb
-RUN rm -rf apt-ntop.deb
+RUN curl -s --remote-name http://packages.ntop.org/apt/16.04/all/apt-ntop-stable.deb
+RUN sudo dpkg -i apt-ntop-stable.deb
+RUN rm -rf apt-ntop-stable.deb
 
 RUN apt-get update
 RUN apt-get -y -q install ntopng redis-server libpcap0.8 libmysqlclient18

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Luca Deri <deri@ntop.org>
 RUN apt-get update
 RUN apt-get -y -q install curl
 RUN curl -s --remote-name http://packages.ntop.org/apt/16.04/all/apt-ntop-stable.deb
-RUN sudo dpkg -i apt-ntop-stable.deb
+RUN dpkg -i apt-ntop-stable.deb
 RUN rm -rf apt-ntop-stable.deb
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN dpkg -i apt-ntop-stable.deb
 RUN rm -rf apt-ntop-stable.deb
 
 RUN apt-get update
-RUN apt-get -y -q install ntopng redis-server libpcap0.8 libmysqlclient18
+RUN apt-get -y -q install ntopng redis-server libpcap0.8 libmysqlclient-dev
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION

This should bring the docker image you'd so kindly built forward to the modern day a little.

I'm passing ['--community'] into my docker container so it doesn't try to run in commercial/professional mode -- it eventually dies for some reason when one does that, and i've not yet taken the time to figure out why.
